### PR TITLE
[mpris] Made the Mpris void class a singleton

### DIFF
--- a/declarative/mprisplugin.cpp
+++ b/declarative/mprisplugin.cpp
@@ -41,7 +41,7 @@ MprisPlugin::~MprisPlugin() {
 }
 
 void MprisPlugin::registerTypes(const char *uri) {
-    qmlRegisterType<Mpris>(uri, 1, 0, "Mpris");
+    qmlRegisterSingletonType<Mpris>(uri, 1, 0, "Mpris", Mpris::api_factory);
     qmlRegisterType<MprisPlayer>(uri, 1, 0, "MprisPlayer");
     qmlRegisterType<MprisManager>(uri, 1, 0, "MprisManager");
 }

--- a/example/qml/MprisControls.qml
+++ b/example/qml/MprisControls.qml
@@ -40,7 +40,7 @@ Item {
             id: artistLabel
 
             text: if (mprisManager.currentService) {
-                var artistTag = mpris.metadataToString(Mpris.Artist)
+                var artistTag = Mpris.metadataToString(Mpris.Artist)
 
                 return (artistTag in mprisManager.metadata) ? mprisManager.metadata[artistTag].toString() : ""
             }
@@ -53,7 +53,7 @@ Item {
             id: songLabel
 
             text: if (mprisManager.currentService) {
-                var titleTag = mpris.metadataToString(Mpris.Title)
+                var titleTag = Mpris.metadataToString(Mpris.Title)
 
                 return (titleTag in mprisManager.metadata) ? mprisManager.metadata[titleTag].toString() : ""
             }
@@ -103,10 +103,6 @@ Item {
                 }
             }
         }
-    }
-
-    Mpris {
-        id: mpris
     }
 }
 

--- a/example/qml/player.qml
+++ b/example/qml/player.qml
@@ -209,7 +209,7 @@ Item {
         onArtistChanged: {
             var metadata = mprisPlayer.metadata
 
-            metadata[mpris.metadataToString(Mpris.Artist)] = [artist] // List of strings
+            metadata[Mpris.metadataToString(Mpris.Artist)] = [artist] // List of strings
 
             mprisPlayer.metadata = metadata
         }
@@ -217,13 +217,9 @@ Item {
         onSongChanged: {
             var metadata = mprisPlayer.metadata
 
-            metadata[mpris.metadataToString(Mpris.Title)] = song // String
+            metadata[Mpris.metadataToString(Mpris.Title)] = song // String
 
             mprisPlayer.metadata = metadata
         }
-    }
-
-    Mpris {
-        id: mpris
     }
 }

--- a/rpm/mpris-qt.spec
+++ b/rpm/mpris-qt.spec
@@ -1,7 +1,7 @@
 Name:       mpris-qt5
 
 Summary:    Qt and QML MPRIS interface and adaptor
-Version:    0.0.2
+Version:    0.0.3
 Release:    1
 Group:      Development/Libraries
 License:    LGPL 2.1

--- a/src/mpris.cpp
+++ b/src/mpris.cpp
@@ -25,6 +25,9 @@
 
 #include "mpris.h"
 
+#include <QQmlEngine>
+#include <QJSEngine>
+
 static const char *playbackStatusStrings[] = { "Playing", "Paused", "Stopped" };
 static const char *loopStatusStrings[] = { "None", "Track", "Playlist" };
 static const char *metadataStrings[] = { "mpris:trackid", "mpris:length", "mpris:artUrl", "xesam:album", "xesam:albumArtist", "xesam:artist", "xesam:asText", "xesam:audioBPM", "xesam:autoRating", "xesam:comment", "xesam:composer", "xesam:contentCreated", "xesam:discNumber", "xesam:firstUsed", "xesam:genre", "xesam:lastUsed", "xesam:lyricist", "xesam:title", "xesam:trackNumber", "xesam:url", "xesam:useCount", "xesam:userRating" };
@@ -37,6 +40,11 @@ Mpris::Mpris(QObject *parent)
 
 Mpris::~Mpris()
 {
+}
+
+QObject *Mpris::api_factory(QQmlEngine *, QJSEngine *)
+{
+    return new Mpris();
 }
 
 QString Mpris::metadataToString(Mpris::Metadata metadata)

--- a/src/mpris.h
+++ b/src/mpris.h
@@ -31,6 +31,9 @@
 #include <QtCore/QObject>
 #include <QtCore/QString>
 
+class QQmlEngine;
+class QJSEngine;
+
 class MPRIS_QT_EXPORT Mpris : public QObject
 {
     Q_OBJECT
@@ -81,6 +84,8 @@ public:
 
     Mpris(QObject *parent = 0);
     ~Mpris();
+
+    static QObject *api_factory(QQmlEngine *, QJSEngine *);
 
     Q_INVOKABLE static QString metadataToString(Metadata metadata);
 


### PR DESCRIPTION
This way we won't have to manually create an
instance just to use its enumerations or static
methods.
