### PR TITLE
[declarative] Fix qml plugin name, mpris to qtmpris

### DIFF
--- a/declarative/declarative.pro
+++ b/declarative/declarative.pro
@@ -15,7 +15,7 @@ EXAMPLE = ../example/declarative/*
 OTHER_FILES += $${EXAMPLE}
 
 TARGET = $${MPRISQTLIB}-qml-plugin
-PLUGIN_IMPORT_PATH = org/nemomobile/mpris
+PLUGIN_IMPORT_PATH = org/nemomobile/qtmpris
 
 QMAKE_SUBSTITUTES = qmldir.in
 

--- a/declarative/qmldir.in
+++ b/declarative/qmldir.in
@@ -1,2 +1,2 @@
-module org.nemomobile.mpris
+module org.nemomobile.qtmpris
 plugin $${TARGET}


### PR DESCRIPTION
Examples fail to load module qtmpris because it's not installed in the right place.
