### PR TITLE
Remove unnecessary warnings

### DIFF
--- a/declarative/mprisplugin.h
+++ b/declarative/mprisplugin.h
@@ -30,15 +30,16 @@
 #include <QtGlobal>
 
 
-class MprisPlugin : public QQmlExtensionPlugin {
-  Q_OBJECT
-  Q_PLUGIN_METADATA(IID "org.nemomobile.mpris")
+class MprisPlugin : public QQmlExtensionPlugin
+{
+    Q_OBJECT
+    Q_PLUGIN_METADATA(IID "org.nemomobile.mpris")
 
 public:
-  MprisPlugin(QObject *parent = 0);
-  ~MprisPlugin();
+    MprisPlugin(QObject *parent = 0);
+    ~MprisPlugin();
 
-  virtual void registerTypes(const char *uri);
+    virtual void registerTypes(const char *uri);
 };
 
 

--- a/src/mpris.cpp
+++ b/src/mpris.cpp
@@ -44,7 +44,7 @@ Mpris::~Mpris()
 
 QObject *Mpris::api_factory(QQmlEngine *, QJSEngine *)
 {
-    return new Mpris();
+    return new Mpris;
 }
 
 QString Mpris::metadataToString(Mpris::Metadata metadata)

--- a/src/mprisplayer.cpp
+++ b/src/mprisplayer.cpp
@@ -553,17 +553,17 @@ void MprisPlayer::unregisterService()
     }
 }
 
-bool MprisPlayer::notifyPropertiesChanged(const QString& interfaceName, const QVariantMap &changedProperties, const QStringList &invalidatedProperties) const
+void MprisPlayer::notifyPropertiesChanged(const QString& interfaceName, const QVariantMap &changedProperties, const QStringList &invalidatedProperties) const
 {
     if (m_serviceName.isEmpty()) {
-        return false;
+        return;
     }
 
     QDBusConnection connection = QDBusConnection::sessionBus();
 
     if (!connection.isConnected()) {
         qmlInfo(this) << "Failed attempting to connect to DBus";
-        return false;
+        return;
     }
 
     QDBusMessage message = QDBusMessage::createSignal(mprisObjectPath,
@@ -574,5 +574,7 @@ bool MprisPlayer::notifyPropertiesChanged(const QString& interfaceName, const QV
     arguments << QVariant(interfaceName) << QVariant(changedProperties) << QVariant(invalidatedProperties);
     message.setArguments(arguments);
 
-    return connection.send(message);
+    if (!connection.send(message)) {
+        qmlInfo(this) << "Failed to send DBus property notification signal";
+    }
 }

--- a/src/mprisplayer.h
+++ b/src/mprisplayer.h
@@ -207,7 +207,7 @@ private:
 
     void registerService();
     void unregisterService();
-    bool notifyPropertiesChanged(const QString& interfaceName, const QVariantMap &changedProperties, const QStringList &invalidatedProperties) const;
+    void notifyPropertiesChanged(const QString& interfaceName, const QVariantMap &changedProperties, const QStringList &invalidatedProperties) const;
 
     MprisRootAdaptor *m_mprisRootAdaptor;
     MprisPlayerAdaptor *m_mprisPlayerAdaptor;

--- a/src/mprisplayeradaptor.cpp
+++ b/src/mprisplayeradaptor.cpp
@@ -475,9 +475,7 @@ void MprisPlayerAdaptor::onCanControlChanged() const
         return;
     }
 
-    if (!player->notifyPropertiesChanged(mprisPlayerInterface, changedProperties, QStringList())) {
-        qmlInfo(this) << "Failed notifying change on property";
-    }
+    player->notifyPropertiesChanged(mprisPlayerInterface, changedProperties, QStringList());
 }
 
 void MprisPlayerAdaptor::onCanGoNextChanged() const
@@ -491,9 +489,7 @@ void MprisPlayerAdaptor::onCanGoNextChanged() const
     QVariantMap changedProperties;
     changedProperties[QStringLiteral("CanGoNext")] = QVariant(player->canGoNext());
 
-    if (!player->notifyPropertiesChanged(mprisPlayerInterface, changedProperties, QStringList())) {
-        qmlInfo(this) << "Failed notifying change on property";
-    }
+    player->notifyPropertiesChanged(mprisPlayerInterface, changedProperties, QStringList());
 }
 
 void MprisPlayerAdaptor::onCanGoPreviousChanged() const
@@ -507,9 +503,7 @@ void MprisPlayerAdaptor::onCanGoPreviousChanged() const
     QVariantMap changedProperties;
     changedProperties[QStringLiteral("CanGoPrevious")] = QVariant(player->canGoPrevious());
 
-    if (!player->notifyPropertiesChanged(mprisPlayerInterface, changedProperties, QStringList())) {
-        qmlInfo(this) << "Failed notifying change on property";
-    }
+    player->notifyPropertiesChanged(mprisPlayerInterface, changedProperties, QStringList());
 }
 
 void MprisPlayerAdaptor::onCanPauseChanged() const
@@ -523,9 +517,7 @@ void MprisPlayerAdaptor::onCanPauseChanged() const
     QVariantMap changedProperties;
     changedProperties[QStringLiteral("CanPause")] = QVariant(player->canPause());
 
-    if (!player->notifyPropertiesChanged(mprisPlayerInterface, changedProperties, QStringList())) {
-        qmlInfo(this) << "Failed notifying change on property";
-    }
+    player->notifyPropertiesChanged(mprisPlayerInterface, changedProperties, QStringList());
 }
 
 void MprisPlayerAdaptor::onCanPlayChanged() const
@@ -539,9 +531,7 @@ void MprisPlayerAdaptor::onCanPlayChanged() const
     QVariantMap changedProperties;
     changedProperties[QStringLiteral("CanPlay")] = QVariant(player->canPlay());
 
-    if (!player->notifyPropertiesChanged(mprisPlayerInterface, changedProperties, QStringList())) {
-        qmlInfo(this) << "Failed notifying change on property";
-    }
+    player->notifyPropertiesChanged(mprisPlayerInterface, changedProperties, QStringList());
 }
 
 void MprisPlayerAdaptor::onCanSeekChanged() const
@@ -555,9 +545,7 @@ void MprisPlayerAdaptor::onCanSeekChanged() const
     QVariantMap changedProperties;
     changedProperties[QStringLiteral("CanSeek")] = QVariant(player->canSeek());
 
-    if (!player->notifyPropertiesChanged(mprisPlayerInterface, changedProperties, QStringList())) {
-        qmlInfo(this) << "Failed notifying change on property";
-    }
+    player->notifyPropertiesChanged(mprisPlayerInterface, changedProperties, QStringList());
 }
 
 void MprisPlayerAdaptor::onLoopStatusChanged() const
@@ -567,9 +555,7 @@ void MprisPlayerAdaptor::onLoopStatusChanged() const
     QVariantMap changedProperties;
     changedProperties[QStringLiteral("LoopStatus")] = QVariant(Mpris::enumerationToString(player->loopStatus()));
 
-    if (!player->notifyPropertiesChanged(mprisPlayerInterface, changedProperties, QStringList())) {
-        qmlInfo(this) << "Failed notifying change on property";
-    }
+    player->notifyPropertiesChanged(mprisPlayerInterface, changedProperties, QStringList());
 }
 
 void MprisPlayerAdaptor::onMaximumRateChanged() const
@@ -584,9 +570,7 @@ void MprisPlayerAdaptor::onMaximumRateChanged() const
     QVariantMap changedProperties;
     changedProperties[QStringLiteral("MaximumRate")] = QVariant(player->maximumRate());
 
-    if (!player->notifyPropertiesChanged(mprisPlayerInterface, changedProperties, QStringList())) {
-        qmlInfo(this) << "Failed notifying change on property";
-    }
+    player->notifyPropertiesChanged(mprisPlayerInterface, changedProperties, QStringList());
 }
 
 void MprisPlayerAdaptor::onMetadataChanged() const
@@ -596,9 +580,7 @@ void MprisPlayerAdaptor::onMetadataChanged() const
     QVariantMap changedProperties;
     changedProperties[QStringLiteral("Metadata")] = QVariant(player->metadata());
 
-    if (!player->notifyPropertiesChanged(mprisPlayerInterface, changedProperties, QStringList())) {
-        qmlInfo(this) << "Failed notifying change on property";
-    }
+    player->notifyPropertiesChanged(mprisPlayerInterface, changedProperties, QStringList());
 }
 
 void MprisPlayerAdaptor::onMinimumRateChanged() const
@@ -613,9 +595,7 @@ void MprisPlayerAdaptor::onMinimumRateChanged() const
     QVariantMap changedProperties;
     changedProperties[QStringLiteral("MinimumRate")] = QVariant(player->minimumRate() < 0 ? 0 : player->minimumRate());
 
-    if (!player->notifyPropertiesChanged(mprisPlayerInterface, changedProperties, QStringList())) {
-        qmlInfo(this) << "Failed notifying change on property";
-    }
+    player->notifyPropertiesChanged(mprisPlayerInterface, changedProperties, QStringList());
 }
 
 void MprisPlayerAdaptor::onPlaybackStatusChanged() const
@@ -625,9 +605,7 @@ void MprisPlayerAdaptor::onPlaybackStatusChanged() const
     QVariantMap changedProperties;
     changedProperties[QStringLiteral("PlaybackStatus")] = QVariant(Mpris::enumerationToString(player->playbackStatus()));
 
-    if (!player->notifyPropertiesChanged(mprisPlayerInterface, changedProperties, QStringList())) {
-        qmlInfo(this) << "Failed notifying change on property";
-    }
+    player->notifyPropertiesChanged(mprisPlayerInterface, changedProperties, QStringList());
 }
 
 void MprisPlayerAdaptor::onRateChanged() const
@@ -642,9 +620,7 @@ void MprisPlayerAdaptor::onRateChanged() const
     QVariantMap changedProperties;
     changedProperties[QStringLiteral("Rate")] = QVariant(player->rate());
 
-    if (!player->notifyPropertiesChanged(mprisPlayerInterface, changedProperties, QStringList())) {
-        qmlInfo(this) << "Failed notifying change on property";
-    }
+    player->notifyPropertiesChanged(mprisPlayerInterface, changedProperties, QStringList());
 }
 
 void MprisPlayerAdaptor::onShuffleChanged() const
@@ -654,9 +630,7 @@ void MprisPlayerAdaptor::onShuffleChanged() const
     QVariantMap changedProperties;
     changedProperties[QStringLiteral("Shuffle")] = QVariant(player->shuffle());
 
-    if (!player->notifyPropertiesChanged(mprisPlayerInterface, changedProperties, QStringList())) {
-        qmlInfo(this) << "Failed notifying change on property";
-    }
+    player->notifyPropertiesChanged(mprisPlayerInterface, changedProperties, QStringList());
 }
 
 void MprisPlayerAdaptor::onVolumeChanged() const
@@ -666,7 +640,5 @@ void MprisPlayerAdaptor::onVolumeChanged() const
     QVariantMap changedProperties;
     changedProperties[QStringLiteral("Volume")] = QVariant(player->volume() < 0 ? 0 : player->volume());
 
-    if (!player->notifyPropertiesChanged(mprisPlayerInterface, changedProperties, QStringList())) {
-        qmlInfo(this) << "Failed notifying change on property";
-    }
+    player->notifyPropertiesChanged(mprisPlayerInterface, changedProperties, QStringList());
 }

--- a/src/mprisrootadaptor.cpp
+++ b/src/mprisrootadaptor.cpp
@@ -160,9 +160,7 @@ void MprisRootAdaptor::onCanQuitChanged() const
     QVariantMap changedProperties;
     changedProperties[QStringLiteral("CanQuit")] = QVariant(player->canQuit());
 
-    if (!player->notifyPropertiesChanged(mprisRootInterface, changedProperties, QStringList())) {
-        qmlInfo(this) << "Failed notifying change on property";
-    }
+    player->notifyPropertiesChanged(mprisRootInterface, changedProperties, QStringList());
 }
 
 void MprisRootAdaptor::onCanRaiseChanged() const
@@ -172,9 +170,7 @@ void MprisRootAdaptor::onCanRaiseChanged() const
     QVariantMap changedProperties;
     changedProperties[QStringLiteral("CanRaise")] = QVariant(player->canRaise());
 
-    if (!player->notifyPropertiesChanged(mprisRootInterface, changedProperties, QStringList())) {
-        qmlInfo(this) << "Failed notifying change on property";
-    }
+    player->notifyPropertiesChanged(mprisRootInterface, changedProperties, QStringList());
 }
 
 void MprisRootAdaptor::onCanSetFullscreenChanged() const
@@ -184,9 +180,7 @@ void MprisRootAdaptor::onCanSetFullscreenChanged() const
     QVariantMap changedProperties;
     changedProperties[QStringLiteral("CanSetFullscreen")] = QVariant(player->canSetFullscreen());
 
-    if (!player->notifyPropertiesChanged(mprisRootInterface, changedProperties, QStringList())) {
-        qmlInfo(this) << "Failed notifying change on property";
-    }
+    player->notifyPropertiesChanged(mprisRootInterface, changedProperties, QStringList());
 }
 
 void MprisRootAdaptor::onDesktopEntryChanged() const
@@ -196,9 +190,7 @@ void MprisRootAdaptor::onDesktopEntryChanged() const
     QVariantMap changedProperties;
     changedProperties[QStringLiteral("DesktopEntry")] = QVariant(player->desktopEntry());
 
-    if (!player->notifyPropertiesChanged(mprisRootInterface, changedProperties, QStringList())) {
-        qmlInfo(this) << "Failed notifying change on property";
-    }
+    player->notifyPropertiesChanged(mprisRootInterface, changedProperties, QStringList());
 }
 
 void MprisRootAdaptor::onFullscreenChanged() const
@@ -208,9 +200,7 @@ void MprisRootAdaptor::onFullscreenChanged() const
     QVariantMap changedProperties;
     changedProperties[QStringLiteral("Fullscreen")] = QVariant(player->fullscreen());
 
-    if (!player->notifyPropertiesChanged(mprisRootInterface, changedProperties, QStringList())) {
-        qmlInfo(this) << "Failed notifying change on property";
-    }
+    player->notifyPropertiesChanged(mprisRootInterface, changedProperties, QStringList());
 }
 
 void MprisRootAdaptor::onHasTrackListChanged() const
@@ -220,9 +210,7 @@ void MprisRootAdaptor::onHasTrackListChanged() const
     QVariantMap changedProperties;
     changedProperties[QStringLiteral("HasTrackList")] = QVariant(player->hasTrackList());
 
-    if (!player->notifyPropertiesChanged(mprisRootInterface, changedProperties, QStringList())) {
-        qmlInfo(this) << "Failed notifying change on property";
-    }
+    player->notifyPropertiesChanged(mprisRootInterface, changedProperties, QStringList());
 }
 
 void MprisRootAdaptor::onIdentityChanged() const
@@ -232,9 +220,7 @@ void MprisRootAdaptor::onIdentityChanged() const
     QVariantMap changedProperties;
     changedProperties[QStringLiteral("Identity")] = QVariant(player->identity());
 
-    if (!player->notifyPropertiesChanged(mprisRootInterface, changedProperties, QStringList())) {
-        qmlInfo(this) << "Failed notifying change on property";
-    }
+    player->notifyPropertiesChanged(mprisRootInterface, changedProperties, QStringList());
 }
 
 void MprisRootAdaptor::onSupportedUriSchemesChanged() const
@@ -244,9 +230,7 @@ void MprisRootAdaptor::onSupportedUriSchemesChanged() const
     QVariantMap changedProperties;
     changedProperties[QStringLiteral("SupportedUriSchemes")] = QVariant(player->supportedUriSchemes());
 
-    if (!player->notifyPropertiesChanged(mprisRootInterface, changedProperties, QStringList())) {
-        qmlInfo(this) << "Failed notifying change on property";
-    }
+    player->notifyPropertiesChanged(mprisRootInterface, changedProperties, QStringList());
 }
 
 void MprisRootAdaptor::onSupportedMimeTypesChanged() const
@@ -256,7 +240,5 @@ void MprisRootAdaptor::onSupportedMimeTypesChanged() const
     QVariantMap changedProperties;
     changedProperties[QStringLiteral("SupportedMimeTypes")] = QVariant(player->supportedMimeTypes());
 
-    if (!player->notifyPropertiesChanged(mprisRootInterface, changedProperties, QStringList())) {
-        qmlInfo(this) << "Failed notifying change on property";
-    }
+    player->notifyPropertiesChanged(mprisRootInterface, changedProperties, QStringList());
 }


### PR DESCRIPTION
In QML, the order of property assignment is undeterministic. Service is registered when serviceName is set, no need to warn on notify failures before that. Or really ever since failed service registration creates warnings anyway.

Ideally could postpone service registration until qml component is completed to avoid unnecessary change signaling.
